### PR TITLE
Resolve #26

### DIFF
--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -8,7 +8,7 @@ import { alertState } from '@/states/AlertAtom'
 export const AppAlert: FC = () => {
   const [alert, setAlert] = useRecoilState(alertState)
   const handleCloseAlert = (): void => {
-    setAlert({ isShow: false, message: '', severity: 'error' })
+    setAlert({ isShow: false, message: '' })
   }
 
   return (
@@ -16,14 +16,14 @@ export const AppAlert: FC = () => {
       open={alert.isShow}
       autoHideDuration={4000}
       onClose={handleCloseAlert}
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      sx={{ mt: 10 }}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      sx={{ mb: 9 }}
     >
       <Alert
         onClose={handleCloseAlert}
-        severity={alert.severity}
+        icon={false}
         variant='filled'
-        sx={{ backgroundColor: 'black', borderRadius: 2, color: 'white', fontWeight: 'bold' }}
+        sx={{ backgroundColor: '#323232', borderRadius: 2, color: 'white', fontWeight: 'bold' }}
       >
         {alert.message}
       </Alert>

--- a/src/components/Layouts/BottomNavigation/index.tsx
+++ b/src/components/Layouts/BottomNavigation/index.tsx
@@ -26,7 +26,7 @@ export const BottomNavigation: FC = () => {
   const naviActions: readonly NaviAction[] = [
     { label: 'ホーム', icon: <HomeRoundedIcon />, path: '' },
     { label: 'お気に入り', icon: <StarRoundedIcon />, path: 'favorited' },
-    { label: 'マイフォルダ', icon: <FolderRoundedIcon />, path: 'myfolders' },
+    { label: 'フォルダ', icon: <FolderRoundedIcon />, path: 'myfolders' },
     { label: '探す', icon: <SearchRoundedIcon />, path: 'seacrh' },
   ]
 
@@ -44,6 +44,8 @@ export const BottomNavigation: FC = () => {
         bottom: 0,
         left: 0,
         right: 0,
+        borderTopLeftRadius: 15,
+        borderTopRightRadius: 15,
       }}
     >
       {naviActions.map((action) => {

--- a/src/components/Layouts/FloatingActionButton/index.tsx
+++ b/src/components/Layouts/FloatingActionButton/index.tsx
@@ -68,7 +68,14 @@ export const FloatingActionButton: FC = () => {
           <AddIcon sx={{ fontWeight: 'bold' }} />
         </Fab>
       </Box>
-      <Drawer anchor='bottom' open={openDrawer} onClose={() => setOpenDrawer(false)}>
+      <Drawer
+        anchor='bottom'
+        open={openDrawer}
+        onClose={() => setOpenDrawer(false)}
+        PaperProps={{
+          style: { borderTopLeftRadius: 15, borderTopRightRadius: 15 },
+        }}
+      >
         <Grid
           container
           alignItems='center'

--- a/src/components/Layouts/FloatingActionButton/index.tsx
+++ b/src/components/Layouts/FloatingActionButton/index.tsx
@@ -8,12 +8,13 @@ import Fab from '@mui/material/Fab'
 import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
 import { FC, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { useMedia } from '@/hooks/useMedia'
 import { isAuthenticatedState } from '@/states/AuthAtom'
 import { isOpenCreateFolderDialogState } from '@/states/isOpenCreateFolderDialogState'
+import { RouterParams } from '@/types'
 
 export type DialogType = 'addLink' | 'createFolder'
 
@@ -23,6 +24,8 @@ export const FloatingActionButton: FC = () => {
   const setIsOpenNewFolderDialog = useSetRecoilState(isOpenCreateFolderDialogState)
   const isAuthenticated = useRecoilValue(isAuthenticatedState)
   const navigate = useNavigate()
+  const location = useLocation()
+  const { folderId, linkId } = useParams<RouterParams>()
 
   const actions = [
     {
@@ -43,7 +46,14 @@ export const FloatingActionButton: FC = () => {
     },
   ]
 
-  if (!isAuthenticated || !isMobileScreen) return null
+  if (
+    !isAuthenticated ||
+    !isMobileScreen ||
+    location.pathname === '/new/link' ||
+    location.pathname === `/folder/${folderId as string}/edit` ||
+    location.pathname === `/folder/${folderId as string}/link/${linkId as string}`
+  )
+    return null
 
   return (
     <>

--- a/src/features/auth/components/Header.tsx
+++ b/src/features/auth/components/Header.tsx
@@ -6,7 +6,7 @@ import { FC } from 'react'
 import { Link } from '@/components/Elements/Link'
 
 export const AuthHeader: FC = () => (
-  <AppBar elevation={0} sx={{ backgroundColor: 'secondary.light', mb: 5 }}>
+  <AppBar position='static' elevation={0} sx={{ backgroundColor: 'secondary.light', mb: 5 }}>
     <Toolbar>
       <Link path='/'>
         <Typography color='primary' component='span' noWrap variant='h6'>

--- a/src/features/auth/components/Layout.tsx
+++ b/src/features/auth/components/Layout.tsx
@@ -9,7 +9,6 @@ import { FC, ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { LinkButton } from '@/components/Elements/Button/LinkButton'
-import { Link } from '@/components/Elements/Link'
 
 type AuthLayoutProps = {
   children: ReactNode
@@ -20,7 +19,7 @@ export const AuthLayout: FC<AuthLayoutProps> = ({ children }) => {
 
   return (
     <>
-      <Container component='main' maxWidth='xs' sx={{ my: 10 }}>
+      <Container component='main' maxWidth='xs' sx={{ mt: 3, mb: 10 }}>
         <Box
           sx={{
             display: 'flex',
@@ -38,16 +37,20 @@ export const AuthLayout: FC<AuthLayoutProps> = ({ children }) => {
         {children}
         <Stack direction='column' justifyContent='center' sx={{ textAlign: 'center' }}>
           <LinkButton
-            color='secondary'
             fullWidth={true}
             label='パスワードを忘れた場合はこちら'
             path='/reset_password'
-            variant='contained'
+            size='small'
+            variant='text'
           />
           <Divider sx={{ my: 4 }} />
-          <Link path={location.pathname === '/signup' ? '/login' : '/signup'} underline='always'>
-            {location.pathname === '/signup' ? 'ログイン' : '新規登録'}はこちら
-          </Link>
+          <LinkButton
+            fullWidth={true}
+            label={location.pathname === '/signup' ? 'ログイン' : '新規登録'}
+            path={location.pathname === '/signup' ? '/login' : '/signup'}
+            size='small'
+            variant='text'
+          />
         </Stack>
       </Container>
     </>

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -70,7 +70,6 @@ export const LoginForm: FC = () => {
         <TextField
           fullWidth
           required
-          autoFocus
           autoComplete='email'
           size='small'
           type='email'
@@ -106,6 +105,7 @@ export const LoginForm: FC = () => {
           fullWidth={true}
           isLoading={isLoading}
           label='ログイン'
+          size='large'
           type='submit'
         />
       </Box>

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -73,7 +73,6 @@ export const SignupForm: FC = () => {
         <TextField
           fullWidth
           required
-          autoFocus
           autoComplete='email'
           size='small'
           type='email'
@@ -125,6 +124,7 @@ export const SignupForm: FC = () => {
           fullWidth={true}
           isLoading={isLoading}
           label='新規登録'
+          size='large'
           type='submit'
         />
       </Box>

--- a/src/features/auth/hooks/useGuestLogin.tsx
+++ b/src/features/auth/hooks/useGuestLogin.tsx
@@ -35,13 +35,12 @@ export const useGuestLogin = (): UseGuestLogin => {
         res.data.data.id != null && setCookie(null, 'userId', res.data.data.id, option)
         setAuthenticated(true)
         navigate('/')
-        setAlert({ isShow: true, message: 'ゲストユーザーでログインしました', severity: 'success' })
+        setAlert({ isShow: true, message: 'ゲストユーザーでログインしました' })
       })
       .catch(() => {
         setAlert({
           isShow: true,
           message: 'ログインに失敗しました。管理者までご連絡ください。',
-          severity: 'error',
         })
       })
     setIsLoading(false)

--- a/src/features/auth/hooks/useLogin.tsx
+++ b/src/features/auth/hooks/useLogin.tsx
@@ -42,7 +42,7 @@ export const useLogin = (): UseLogin => {
         res.data.data.id != null && setCookie(null, 'userId', res.data.data.id, option)
         setAuthenticated(true)
         navigate('/')
-        setAlert({ isShow: true, message: 'ログインに成功しました', severity: 'success' })
+        setAlert({ isShow: true, message: 'ログインに成功しました' })
       })
       .catch((err) => {
         setErrorMessage(err.response.data.errors.full_messages)

--- a/src/features/auth/hooks/useLogout.tsx
+++ b/src/features/auth/hooks/useLogout.tsx
@@ -35,10 +35,10 @@ export const useLogout = (): UseLogout => {
         destroyCookie(null, 'userId', option)
         setAuthenticated(false)
         navigate('/')
-        setAlert({ isShow: true, message: 'ログアウトに成功しました', severity: 'success' })
+        setAlert({ isShow: true, message: 'ログアウトに成功しました' })
       })
       .catch(() => {
-        setAlert({ isShow: true, message: 'ログアウトに失敗しました', severity: 'error' })
+        setAlert({ isShow: true, message: 'ログアウトに失敗しました' })
       })
     setIsLoading(false)
   }

--- a/src/features/auth/hooks/useSignup.tsx
+++ b/src/features/auth/hooks/useSignup.tsx
@@ -44,7 +44,7 @@ export const useSignup = (): UseSignup => {
         res.data.data.id != null && setCookie(null, 'userId', res.data.data.id, option)
         setAuthenticated(true)
         navigate('/')
-        setAlert({ isShow: true, message: '新規登録に成功しました', severity: 'success' })
+        setAlert({ isShow: true, message: '新規登録に成功しました' })
       })
       .catch((err) => {
         setErrorMessage(err.response.data.errors.full_messages)

--- a/src/features/folder/components/Dialog/CreateFolderDialog.tsx
+++ b/src/features/folder/components/Dialog/CreateFolderDialog.tsx
@@ -84,7 +84,6 @@ export const CreateFolderDialog: FC<CreateFolderDialogProps> = ({ handleCloseDia
           </Typography>
           <TextField
             fullWidth
-            autoFocus
             placeholder='フォルダ名を入力'
             size='small'
             type='text'

--- a/src/features/folder/components/Dialog/DeleteFolderDialog.tsx
+++ b/src/features/folder/components/Dialog/DeleteFolderDialog.tsx
@@ -42,6 +42,9 @@ export const DeleteFolderDialog: FC<DeleteFolderDialogProps> = ({
       maxWidth='xs'
       onClose={() => handleCloseDialog()}
       open={open}
+      PaperProps={{
+        style: { borderRadius: 15 },
+      }}
       sx={{ textAlign: 'center' }}
     >
       <Box sx={{ alignItems: 'center', display: 'flex', flexDirection: 'column', mt: 2 }}>

--- a/src/features/folder/hooks/useCreateFolder.tsx
+++ b/src/features/folder/hooks/useCreateFolder.tsx
@@ -36,7 +36,6 @@ export const useCreateFolder = (): UseCreateFolder => {
         setAlert({
           isShow: true,
           message: 'フォルダを作成しました',
-          severity: 'success',
         })
         setResStatus(res.status)
         setMyFolders((prevMyFolders) => {

--- a/src/features/folder/hooks/useDeleteFolder.tsx
+++ b/src/features/folder/hooks/useDeleteFolder.tsx
@@ -38,7 +38,6 @@ export const useDeleteFolder = (): UseDeleteFolder => {
         setAlert({
           isShow: true,
           message: 'フォルダを削除しました',
-          severity: 'success',
         })
       })
       .catch((err) => {

--- a/src/features/folder/hooks/useUpdateFolder.tsx
+++ b/src/features/folder/hooks/useUpdateFolder.tsx
@@ -34,7 +34,6 @@ export const useUpdateFolder = (): UseUpdateFolder => {
         setAlert({
           isShow: true,
           message: 'フォルダを更新しました',
-          severity: 'success',
         })
         navigate(`/folder/${folderId}`)
       })

--- a/src/features/folder/routes/FolderDetails.tsx
+++ b/src/features/folder/routes/FolderDetails.tsx
@@ -156,7 +156,7 @@ export const FolderDetails: FC = () => {
             />
           </Stack>
           {displayFormat === 'list' && (
-            <List sx={{ ...whiteBackgroundProps, p: 2 }}>
+            <List sx={{ ...whiteBackgroundProps, p: 0 }}>
               {folderHasLinks?.map((link: Link) => {
                 return (
                   <LinkListItem

--- a/src/features/folder/routes/FolderDetails.tsx
+++ b/src/features/folder/routes/FolderDetails.tsx
@@ -156,7 +156,7 @@ export const FolderDetails: FC = () => {
             />
           </Stack>
           {displayFormat === 'list' && (
-            <List sx={{ ...whiteBackgroundProps, p: 0 }}>
+            <List sx={{ ...whiteBackgroundProps, pl: 1, pr: 0, py: 2 }}>
               {folderHasLinks?.map((link: Link) => {
                 return (
                   <LinkListItem

--- a/src/features/link/components/LinkCard.tsx
+++ b/src/features/link/components/LinkCard.tsx
@@ -37,7 +37,7 @@ export const LinkCard: FC<LinkCardProps> = ({ folderId, isOwner, link }) => {
     setAnchorEl(event.currentTarget)
   }
 
-  const headerAddActions: MenuItems = [
+  const ownerMenuItems: MenuItems = [
     {
       onClick: () => {
         navigator.clipboard.writeText(link.url)
@@ -58,6 +58,16 @@ export const LinkCard: FC<LinkCardProps> = ({ folderId, isOwner, link }) => {
         setAnchorEl(null)
       },
       text: '削除',
+    },
+  ]
+
+  const notOwnerMenuItems: MenuItems = [
+    {
+      onClick: () => {
+        navigator.clipboard.writeText(link.url)
+        setAnchorEl(null)
+      },
+      text: 'クリップボードにリンクをコピー',
     },
   ]
 
@@ -127,25 +137,21 @@ export const LinkCard: FC<LinkCardProps> = ({ folderId, isOwner, link }) => {
         <Typography component='span' variant='body2' sx={{ mr: 'auto', color: 'secondary.dark' }}>
           {diffTime(new Date(), parseISO(link.updated_at))}
         </Typography>
-        {isOwner && (
-          <>
-            <IconButton onClick={handleOpenMenu} edge='end' size='small'>
-              <MoreVertIcon />
-            </IconButton>
-            <Menu
-              anchorEl={anchorEl}
-              handleCloseMenu={() => setAnchorEl(null)}
-              menuItems={headerAddActions}
-            />
-            {folderId !== undefined && link.id !== undefined && (
-              <DeleteLinkDialog
-                folderId={folderId}
-                linkId={link.id.toString()}
-                handleCloseDialog={() => setOpenDialog(false)}
-                open={openDialog}
-              />
-            )}
-          </>
+        <IconButton onClick={handleOpenMenu} edge='end' size='small'>
+          <MoreVertIcon />
+        </IconButton>
+        <Menu
+          anchorEl={anchorEl}
+          handleCloseMenu={() => setAnchorEl(null)}
+          menuItems={isOwner ? ownerMenuItems : notOwnerMenuItems}
+        />
+        {isOwner && folderId !== undefined && link.id !== undefined && (
+          <DeleteLinkDialog
+            folderId={folderId}
+            linkId={link.id.toString()}
+            handleCloseDialog={() => setOpenDialog(false)}
+            open={openDialog}
+          />
         )}
       </CardActions>
     </Card>

--- a/src/features/link/components/LinkListItem.tsx
+++ b/src/features/link/components/LinkListItem.tsx
@@ -36,7 +36,7 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
     setAnchorEl(event.currentTarget)
   }
 
-  const headerAddActions: MenuItems = [
+  const ownerMenuItems: MenuItems = [
     {
       onClick: () => {
         navigator.clipboard.writeText(link.url)
@@ -57,6 +57,16 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
         setAnchorEl(null)
       },
       text: '削除',
+    },
+  ]
+
+  const notOwnerMenuItems: MenuItems = [
+    {
+      onClick: () => {
+        navigator.clipboard.writeText(link.url)
+        setAnchorEl(null)
+      },
+      text: 'クリップボードにリンクをコピー',
     },
   ]
 
@@ -111,25 +121,21 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
           }
         />
       </ListItemButton>
-      {isOwner && (
-        <>
-          <IconButton onClick={handleOpenMenu} edge='end' size='small'>
-            <MoreVertIcon />
-          </IconButton>
-          <Menu
-            anchorEl={anchorEl}
-            handleCloseMenu={() => setAnchorEl(null)}
-            menuItems={headerAddActions}
-          />
-          {folderId !== undefined && link.id !== undefined && (
-            <DeleteLinkDialog
-              folderId={folderId}
-              linkId={link.id.toString()}
-              handleCloseDialog={() => setOpenDialog(false)}
-              open={openDialog}
-            />
-          )}
-        </>
+      <IconButton onClick={handleOpenMenu} edge='end' size='small'>
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        handleCloseMenu={() => setAnchorEl(null)}
+        menuItems={isOwner ? ownerMenuItems : notOwnerMenuItems}
+      />
+      {isOwner && folderId !== undefined && link.id !== undefined && (
+        <DeleteLinkDialog
+          folderId={folderId}
+          linkId={link.id.toString()}
+          handleCloseDialog={() => setOpenDialog(false)}
+          open={openDialog}
+        />
       )}
     </ListItem>
   )

--- a/src/features/link/components/LinkListItem.tsx
+++ b/src/features/link/components/LinkListItem.tsx
@@ -77,7 +77,7 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
         href={link.url}
         target='_blank'
         underline='none'
-        sx={{ borderRadius: 3 }}
+        sx={{ borderRadius: 3, pr: 0 }}
       >
         <ListItemAvatar sx={{ mr: 1 }}>
           <Image
@@ -96,10 +96,10 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
             <Typography
               variant='subtitle2'
               sx={{
-                display: 'block',
-                whiteSpace: 'nowrap',
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 2,
                 overflow: 'hidden',
-                textOverflow: 'ellipsis',
               }}
             >
               {link.title}
@@ -121,7 +121,7 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
           }
         />
       </ListItemButton>
-      <IconButton onClick={handleOpenMenu} edge='end' size='small'>
+      <IconButton onClick={handleOpenMenu} edge='end' size='small' sx={{ mr: 0.5 }}>
         <MoreVertIcon />
       </IconButton>
       <Menu

--- a/src/features/link/components/LinkListItem.tsx
+++ b/src/features/link/components/LinkListItem.tsx
@@ -77,7 +77,7 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner, link })
         href={link.url}
         target='_blank'
         underline='none'
-        sx={{ borderRadius: 3, pr: 0 }}
+        sx={{ borderRadius: 3, pl: 1, pr: 0 }}
       >
         <ListItemAvatar sx={{ mr: 1 }}>
           <Image

--- a/src/features/link/hooks/useAddLink.tsx
+++ b/src/features/link/hooks/useAddLink.tsx
@@ -42,7 +42,6 @@ export const useAddLink = (): UseAddLink => {
         setAlert({
           isShow: true,
           message: 'リンクを追加しました',
-          severity: 'success',
         })
         setFolderHasLinks((prevFolderHasLinks) => {
           const newFolderHasLinks = [...prevFolderHasLinks, res.data.link]

--- a/src/features/link/hooks/useCreateLink.tsx
+++ b/src/features/link/hooks/useCreateLink.tsx
@@ -7,8 +7,8 @@ import { alertState } from '@/states/AlertAtom'
 import { folderHasLinksState } from '@/states/FolderHasLinksAtom'
 import { authHeaders } from '@/utils/authHeaders'
 
-type UseAddLink = {
-  addLink: (link: params) => Promise<void>
+type UseCreateLink = {
+  createLink: (link: params) => Promise<void>
   errorMessage: string
   isLoading: boolean
   resStatus: number
@@ -20,7 +20,7 @@ type params = {
   folder_id: number
 }
 
-export const useAddLink = (): UseAddLink => {
+export const useCreateLink = (): UseCreateLink => {
   const [isLoading, setIsLoading] = useState(false)
   const [resStatus, setResStatus] = useState(0)
   const [errorMessage, setErrorMessage] = useState('')
@@ -29,7 +29,7 @@ export const useAddLink = (): UseAddLink => {
   const setFolderHasLinks = useSetRecoilState(folderHasLinksState)
   const headers = authHeaders()
 
-  const addLink = async (link: params): Promise<void> => {
+  const createLink = async (link: params): Promise<void> => {
     setIsLoading(true)
     setResStatus(0)
     setErrorMessage('')
@@ -58,7 +58,7 @@ export const useAddLink = (): UseAddLink => {
   }
 
   return {
-    addLink,
+    createLink,
     errorMessage,
     isLoading,
     resStatus,

--- a/src/features/link/hooks/useDeleteLink.tsx
+++ b/src/features/link/hooks/useDeleteLink.tsx
@@ -34,7 +34,6 @@ export const useDeleteLink = (): UseDeleteLink => {
         setAlert({
           isShow: true,
           message: 'フォルダを削除しました',
-          severity: 'success',
         })
         if (folderHasLinks.length !== 0) {
           const afterFolderHasLinks = folderHasLinks.filter((link) => {

--- a/src/features/link/hooks/useUpdateLink.tsx
+++ b/src/features/link/hooks/useUpdateLink.tsx
@@ -35,7 +35,6 @@ export const useUpdateLink = (): UseUpdateLink => {
         setAlert({
           isShow: true,
           message: 'リンクを更新しました',
-          severity: 'success',
         })
         navigate(`/folder/${link.folder_id}`)
       })

--- a/src/features/link/routes/EditLink.tsx
+++ b/src/features/link/routes/EditLink.tsx
@@ -26,12 +26,8 @@ import { DeleteLinkDialog } from '@/features/link/components/DeleteLinkDialog'
 import { useFetchLink } from '@/features/link/hooks/useFetchLink'
 import { useUpdateLink } from '@/features/link/hooks/useUpdateLink'
 import { myFoldersState } from '@/states/MyFoldersAtom'
+import { RouterParams } from '@/types'
 import { whiteBackgroundProps } from '@/utils/mui/whiteBackgroundProps'
-
-type RouterParams = {
-  folderId: string
-  linkId: string
-}
 
 const schema = z.object({
   url: string()

--- a/src/features/link/routes/NewLink.tsx
+++ b/src/features/link/routes/NewLink.tsx
@@ -21,7 +21,7 @@ import { number, string, z } from 'zod'
 import { Button } from '@/components/Elements/Button'
 import { InputLabel } from '@/components/Elements/Form/InputLabel'
 import { useFetchMyFolders } from '@/features/folder/hooks/useFetchMyFolders'
-import { useAddLink } from '@/features/link/hooks/useAddLink'
+import { useCreateLink } from '@/features/link/hooks/useCreateLink'
 import { isOpenCreateFolderDialogState } from '@/states/isOpenCreateFolderDialogState'
 import { myFoldersState } from '@/states/MyFoldersAtom'
 import { whiteBackgroundProps } from '@/utils/mui/whiteBackgroundProps'
@@ -51,7 +51,7 @@ export const NewLink: FC = () => {
   } = useForm<Form>({
     resolver: zodResolver(schema),
   })
-  const { addLink, errorMessage, isLoading } = useAddLink()
+  const { createLink, errorMessage, isLoading } = useCreateLink()
 
   const onSubmit: SubmitHandler<Form> = (data) => {
     const link = {
@@ -59,7 +59,7 @@ export const NewLink: FC = () => {
       title: data.title,
       folder_id: data.folderId,
     }
-    addLink(link)
+    createLink(link)
   }
 
   useEffect(() => {

--- a/src/states/AlertAtom.ts
+++ b/src/states/AlertAtom.ts
@@ -2,7 +2,6 @@ import { atom } from 'recoil'
 type Alert = {
   isShow: boolean
   message: string
-  severity: 'success' | 'info' | 'warning' | 'error'
 }
 
 export const alertState = atom<Alert>({
@@ -10,6 +9,5 @@ export const alertState = atom<Alert>({
   default: {
     isShow: false,
     message: '',
-    severity: 'error',
   },
 })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export type RouterParams = {
-  folderId: string
+  folderId?: string
+  linkId?: string
 }


### PR DESCRIPTION
Closes #26 

- Alert Component 
  - 表示位置を中央下に変更
  - カラーを変更
- ボトムメニューの表示テキストを変更
- 非ログイン時およびリンクの所収者でない場合もメニューボタンを表示し、クリックボードにリンクをコピーできるように修正
- リンク追加・編集ページ、フォルダ編集ページでは右下のFAB を非表示にする
- リンクのリスト表示で2行以上で3点リーダを表示するように修正