### PR TITLE
フォルダへのタグ付け機能を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-hook-form": "^7.37.0",
         "react-router-dom": "^6.4.2",
         "react-scripts": "^5.0.1",
+        "react-tag-input-component": "^2.0.2",
         "recoil": "^0.7.6",
         "web-vitals": "^2.1.4",
         "zod": "^3.19.1"
@@ -14810,6 +14811,15 @@
         }
       }
     },
+    "node_modules/react-tag-input-component": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-tag-input-component/-/react-tag-input-component-2.0.2.tgz",
+      "integrity": "sha512-dydI9luVwwv9vrjE5u1TTnkcOVkOVL6mhFti8r6hLi78V2F2EKWQOLptURz79UYbDHLSk6tnbvGl8FE+sMpADg==",
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -27948,6 +27958,12 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-tag-input-component": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-tag-input-component/-/react-tag-input-component-2.0.2.tgz",
+      "integrity": "sha512-dydI9luVwwv9vrjE5u1TTnkcOVkOVL6mhFti8r6hLi78V2F2EKWQOLptURz79UYbDHLSk6tnbvGl8FE+sMpADg==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-hook-form": "^7.37.0",
     "react-router-dom": "^6.4.2",
     "react-scripts": "^5.0.1",
+    "react-tag-input-component": "^2.0.2",
     "recoil": "^0.7.6",
     "web-vitals": "^2.1.4",
     "zod": "^3.19.1"

--- a/src/components/Elements/Menu/MenuItems.tsx
+++ b/src/components/Elements/Menu/MenuItems.tsx
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react'
 
-export type MenuItems = Array<{
-  icon?: ReactNode
+export type MenuItem = Readonly<{
   onClick?: () => void
-  path?: string
   text: string
+  icon: ReactNode
+  path?: string
+  isShow: boolean
 }>
+
+export type MenuItems = MenuItem[]

--- a/src/components/Elements/Menu/index.tsx
+++ b/src/components/Elements/Menu/index.tsx
@@ -1,46 +1,48 @@
 import MuiMenu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Typography from '@mui/material/Typography'
-import { FC } from 'react'
+import { Dispatch, FC, SetStateAction } from 'react'
+import { Link } from 'react-router-dom'
 
-import { MenuItems } from '@/components/Elements/Menu/MenuItems'
+import { ListItemIcon } from '@/components/Elements/ListItemIcon'
+import { MenuItem as MenuItemType, MenuItems } from '@/components/Elements/Menu/MenuItems'
 
 type MenuProps = {
   anchorEl: null | HTMLElement
-  handleCloseMenu: () => void
+  setAnchorEl: Dispatch<SetStateAction<null | HTMLElement>>
   menuItems: MenuItems
 }
 
-export const Menu: FC<MenuProps> = ({ anchorEl, handleCloseMenu, menuItems }) => {
+export const Menu: FC<MenuProps> = ({ anchorEl, setAnchorEl, menuItems }) => {
   const isOpen = Boolean(anchorEl)
 
   return (
     <MuiMenu
       anchorEl={anchorEl}
-      onClose={handleCloseMenu}
+      onClose={() => setAnchorEl(null)}
       open={isOpen}
       PaperProps={{
         style: { borderRadius: 15 },
       }}
     >
-      {menuItems.map((item) => {
-        return (
-          <MenuItem
-            key={item.text}
-            onClick={item.onClick}
-            sx={{
-              '&:hover': {
-                color: 'white',
-                backgroundColor: 'primary.main',
-              },
-            }}
-          >
-            {item.icon}
-            <Typography component='span' variant='body2'>
-              {item.text}
-            </Typography>
-          </MenuItem>
-        )
+      {menuItems.map((item: MenuItemType) => {
+        return item.path !== undefined
+          ? item.isShow && (
+              <MenuItem key={item.text} component={Link} to={item.path} onClick={item.onClick}>
+                <ListItemIcon>{item.icon}</ListItemIcon>
+                <Typography component='span' variant='body2'>
+                  {item.text}
+                </Typography>
+              </MenuItem>
+            )
+          : item.isShow && (
+              <MenuItem key={item.text} onClick={item.onClick}>
+                <ListItemIcon>{item.icon}</ListItemIcon>
+                <Typography component='span' variant='body2'>
+                  {item.text}
+                </Typography>
+              </MenuItem>
+            )
       })}
     </MuiMenu>
   )

--- a/src/components/Layouts/Header/index.tsx
+++ b/src/components/Layouts/Header/index.tsx
@@ -7,12 +7,11 @@ import Stack from '@mui/material/Stack'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
 import { FC, MouseEvent, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { Button } from '@/components/Elements/Button'
 import { LinkButton } from '@/components/Elements/Button/LinkButton'
-import { Link } from '@/components/Elements/Link'
+import { Link as AppLink } from '@/components/Elements/Link'
 import { Menu } from '@/components/Elements/Menu'
 import { MenuItems } from '@/components/Elements/Menu/MenuItems'
 import { HeaderMenu } from '@/components/Layouts/Header/Menu'
@@ -26,28 +25,29 @@ export const Header: FC = () => {
   const setIsOpenCreateFolderDialog = useSetRecoilState(isOpenCreateFolderDialogState)
   const isAuthenticated = useRecoilValue(isAuthenticatedState)
   const { isDesktopScreen } = useMedia()
-  const navigate = useNavigate()
 
   const handleOpenMenu = (event: MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget)
   }
 
-  const headerAddActions: MenuItems = [
+  const menuItems: MenuItems = [
     {
-      icon: <AddLinkOutlinedIcon sx={{ mr: 1 }} />,
       onClick: () => {
-        navigate('/new/link')
         setAnchorEl(null)
       },
       text: 'リンクを追加',
+      icon: <AddLinkOutlinedIcon />,
+      path: '/new/link',
+      isShow: true,
     },
     {
-      icon: <CreateNewFolderOutlinedIcon sx={{ mr: 1 }} />,
       onClick: () => {
         setIsOpenCreateFolderDialog(true)
         setAnchorEl(null)
       },
       text: 'フォルダを作成',
+      icon: <CreateNewFolderOutlinedIcon />,
+      isShow: true,
     },
   ]
 
@@ -57,7 +57,7 @@ export const Header: FC = () => {
       sx={{ backgroundColor: 'secondary.light', borderBottom: 1, borderColor: '#e0e0e0' }}
     >
       <Toolbar variant={isDesktopScreen ? 'regular' : 'dense'}>
-        <Link path='/'>
+        <AppLink path='/'>
           <Typography
             color='primary'
             component='span'
@@ -67,7 +67,7 @@ export const Header: FC = () => {
           >
             Gathelink
           </Typography>
-        </Link>
+        </AppLink>
         {isAuthenticated && isDesktopScreen && (
           <>
             <Button
@@ -77,11 +77,7 @@ export const Header: FC = () => {
               variant='contained'
               sx={{ ml: 38 }}
             />
-            <Menu
-              anchorEl={anchorEl}
-              handleCloseMenu={() => setAnchorEl(null)}
-              menuItems={headerAddActions}
-            />
+            <Menu anchorEl={anchorEl} setAnchorEl={setAnchorEl} menuItems={menuItems} />
           </>
         )}
         <Box sx={{ flexGrow: 1 }} />

--- a/src/components/Layouts/Header/index.tsx
+++ b/src/components/Layouts/Header/index.tsx
@@ -63,7 +63,12 @@ export const Header: FC = () => {
             component='span'
             noWrap
             variant='h6'
-            sx={{ mr: 2, display: { xs: 'flex', md: 'none' } }}
+            sx={{
+              mr: 2,
+              display: { xs: 'flex', md: 'none' },
+              fontFamily: '-apple-system',
+              fontWeight: 'bold',
+            }}
           >
             Gathelink
           </Typography>

--- a/src/components/Layouts/Sidebar/index.tsx
+++ b/src/components/Layouts/Sidebar/index.tsx
@@ -52,7 +52,13 @@ export const Sidebar: FC = () => {
             sx={{ pl: 2, pr: 1, mb: 2 }}
           >
             <Link path='/' underline='none'>
-              <Typography component='span' color='primary' noWrap variant='h6'>
+              <Typography
+                component='span'
+                color='primary'
+                noWrap
+                variant='h6'
+                sx={{ fontFamily: '-apple-system', fontWeight: 'bold' }}
+              >
                 Gathelink
               </Typography>
             </Link>

--- a/src/features/auth/routes/Login.tsx
+++ b/src/features/auth/routes/Login.tsx
@@ -1,5 +1,14 @@
 import { FC } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
 
 import { LoginForm } from '@/features/auth/components/LoginForm'
+import { isAuthenticatedState } from '@/states/AuthAtom'
 
-export const Login: FC = () => <LoginForm />
+export const Login: FC = () => {
+  const isAuthenticated = useRecoilValue(isAuthenticatedState)
+
+  if (isAuthenticated) return <Navigate to='/myfolders?sort=created_asc' replace={false} />
+
+  return <LoginForm />
+}

--- a/src/features/auth/routes/Signup.tsx
+++ b/src/features/auth/routes/Signup.tsx
@@ -1,5 +1,14 @@
 import { FC } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
 
 import { SignupForm } from '@/features/auth/components/SignupForm'
+import { isAuthenticatedState } from '@/states/AuthAtom'
 
-export const Signup: FC = () => <SignupForm />
+export const Signup: FC = () => {
+  const isAuthenticated = useRecoilValue(isAuthenticatedState)
+
+  if (isAuthenticated) return <Navigate to='/myfolders?sort=created_asc' replace={false} />
+
+  return <SignupForm />
+}

--- a/src/features/folder/components/Dialog/CreateFolderDialog.tsx
+++ b/src/features/folder/components/Dialog/CreateFolderDialog.tsx
@@ -3,16 +3,18 @@ import CreateNewFolderIcon from '@mui/icons-material/CreateNewFolder'
 import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
 import DialogContent from '@mui/material/DialogContent'
+import FormHelperText from '@mui/material/FormHelperText'
 import TextField from '@mui/material/TextField'
-import Typography from '@mui/material/Typography'
-import { Dispatch, FC, SetStateAction, useEffect } from 'react'
+import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
+import { TagsInput } from 'react-tag-input-component'
 import { string, z } from 'zod'
 
 import { Alert } from '@/components/Elements/Alert'
 import { Button } from '@/components/Elements/Button'
 import { Dialog } from '@/components/Elements/Dialog'
 import { DialogActions } from '@/components/Elements/Dialog/DialogActions'
+import { InputLabel } from '@/components/Elements/Form/InputLabel'
 import { usePostFolder } from '@/features/folder/hooks/usePostFolder'
 
 type CreateFolderDialogProps = {
@@ -23,7 +25,7 @@ type CreateFolderDialogProps = {
 const schema = z.object({
   name: string()
     .min(1, 'フォルダ名は必須です')
-    .max(30, 'フォルダ名は 30 文字以下で入力してください')
+    .max(30, 'フォルダ名は30文字以下で入力してください')
     .trim(),
 })
 
@@ -42,11 +44,21 @@ export const CreateFolderDialog: FC<CreateFolderDialogProps> = ({
     resolver: zodResolver(schema),
   })
   const { postFolder, errorMessage, isPosting, resStatus } = usePostFolder()
+  const [tags, setTags] = useState<string[]>([])
+  const [validationMessage, setValidationMessage] = useState('')
 
   const onSubmit: SubmitHandler<Form> = (data) => {
+    for (let i = 0; i < tags.length; i++) {
+      if (tags[i].length > 20) {
+        setValidationMessage('タグは20文字以下で入力してください')
+        return
+      }
+    }
+
     const folder = {
       name: data.name,
       color: '#26a69a',
+      tags,
     }
     postFolder(folder)
   }
@@ -54,6 +66,8 @@ export const CreateFolderDialog: FC<CreateFolderDialogProps> = ({
   useEffect(() => {
     if (resStatus === 201) {
       reset()
+      setTags([])
+      setValidationMessage('')
       setIsOpenDialog(false)
     }
   }, [resStatus, reset])
@@ -69,12 +83,15 @@ export const CreateFolderDialog: FC<CreateFolderDialogProps> = ({
         </Avatar>
       }
     >
-      <DialogContent>
-        <Alert message={errorMessage} />
-        <Box component='form' noValidate onSubmit={handleSubmit(onSubmit)}>
-          <Typography component='p' sx={{ mb: 1 }}>
-            フォルダ名を30文字以下で入力してください。
-          </Typography>
+      <Box component='form' noValidate onSubmit={handleSubmit(onSubmit)}>
+        <DialogContent>
+          <Alert message={errorMessage} />
+          <InputLabel
+            labelTitle='フォルダ名'
+            inputRequirement='フォルダ名は30文字までです'
+            required={true}
+            isShowChip={true}
+          />
           <TextField
             fullWidth
             size='small'
@@ -82,25 +99,34 @@ export const CreateFolderDialog: FC<CreateFolderDialogProps> = ({
             placeholder='フォルダ名'
             error={!(errors.name == null)}
             helperText={errors.name != null ? errors.name.message : ''}
+            sx={{ mb: 4 }}
             {...register('name')}
           />
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button
-          size='large'
-          color='secondary'
-          label='キャンセル'
-          onClick={() => setIsOpenDialog(false)}
-        />
-        <Button
-          size='large'
-          isLoading={isPosting}
-          disabled={isPosting}
-          label='作成する'
-          type='submit'
-        />
-      </DialogActions>
+          <InputLabel
+            labelTitle='タグ名'
+            inputRequirement='タグ名は20文字までです'
+            required={false}
+            isShowChip={true}
+          />
+          <TagsInput value={tags} onChange={setTags} />
+          <FormHelperText error>{validationMessage}</FormHelperText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            size='large'
+            color='secondary'
+            label='キャンセル'
+            onClick={() => setIsOpenDialog(false)}
+          />
+          <Button
+            size='large'
+            isLoading={isPosting}
+            disabled={isPosting}
+            label='作成する'
+            type='submit'
+          />
+        </DialogActions>
+      </Box>
     </Dialog>
   )
 }

--- a/src/features/folder/components/TagList/index.tsx
+++ b/src/features/folder/components/TagList/index.tsx
@@ -1,0 +1,33 @@
+import SellRoundedIcon from '@mui/icons-material/SellRounded'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+import { FC } from 'react'
+import { Link } from 'react-router-dom'
+
+import { Tag } from '@/features/folder/types/Tag'
+
+type TagListProps = {
+  tags?: Tag[]
+}
+
+export const TagList: FC<TagListProps> = ({ tags }) => {
+  if (tags === undefined || tags.length === 0) return null
+
+  return (
+    <Stack direction='row' alignItems='center' spacing={1}>
+      <SellRoundedIcon sx={{ ml: 0.5, color: 'secondary.dark' }} />
+      {tags.map((tag) => {
+        return (
+          <Chip
+            key={tag.id}
+            label={tag.name}
+            variant='outlined'
+            clickable
+            component={Link}
+            to={`/tag/${tag.id}?page=1&sort=created_asc`}
+          />
+        )
+      })}
+    </Stack>
+  )
+}

--- a/src/features/folder/hooks/useFetchFolder.tsx
+++ b/src/features/folder/hooks/useFetchFolder.tsx
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction, useState } from 'react'
 import { useSetRecoilState } from 'recoil'
 
 import { Folder } from '@/features/folder/types/Folder'
+import { Tag } from '@/features/folder/types/Tag'
 import { apiClient } from '@/lib/axios/apiClient'
 import { folderHasLinksState } from '@/states/FolderHasLinksAtom'
 import { authHeaders } from '@/utils/authHeaders'
@@ -14,11 +15,13 @@ type UseFetchFolder = {
   isFetching: boolean
   isOwner: boolean
   resStatus: number
+  tags: string[]
 }
 
 export const useFetchFolder = (): UseFetchFolder => {
   const [errorMessage, setErrorMessage] = useState('')
   const [folder, setFolder] = useState<Folder | undefined>()
+  const [tags, setTags] = useState<string[]>([])
   const [isOwner, setIsOwner] = useState(false)
   const [isFetching, setIsFetching] = useState(false)
   const [resStatus, setResStatus] = useState(0)
@@ -37,6 +40,11 @@ export const useFetchFolder = (): UseFetchFolder => {
         setIsOwner(res.data.is_owner)
         setFolder(res.data.folder)
         setFolderHasLinks(res.data.links)
+        setTags(
+          res.data.folder.tags.map((tag: Tag) => {
+            return tag.name
+          }),
+        )
       })
       .catch((err) => {
         setResStatus(err.response.status)
@@ -55,5 +63,6 @@ export const useFetchFolder = (): UseFetchFolder => {
     isFetching,
     isOwner,
     resStatus,
+    tags,
   }
 }

--- a/src/features/folder/hooks/useFetchTagFolders.tsx
+++ b/src/features/folder/hooks/useFetchTagFolders.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+
+import { Folder } from '@/features/folder/types/Folder'
+import { apiClient } from '@/lib/axios/apiClient'
+import { authHeaders } from '@/utils/authHeaders'
+
+type UseFetchTagFolders = {
+  isFetching: boolean
+  errorMessage: string
+  fetchTagFolders: (tagId: string, page: string, sortType: string) => Promise<void>
+  tag?: string
+  folders?: Folder[]
+  totalPages?: number
+}
+
+export const useFetchTagFolders = (): UseFetchTagFolders => {
+  const [isFetching, setIsFetching] = useState(false)
+  const [tag, setTag] = useState('')
+  const [folders, setFolders] = useState<Folder[] | undefined>()
+  const [totalPages, setTotalPages] = useState<number>()
+  const [errorMessage, setErrorMessage] = useState('')
+  const headers = authHeaders()
+
+  const fetchTagFolders = async (tagId: string, page: string, sortType: string): Promise<void> => {
+    setIsFetching(true)
+    setErrorMessage('')
+
+    await apiClient
+      .get(`/folders/${tagId}/by_tag?page=${page}&sort=${sortType}`, { headers })
+      .then((res) => {
+        setTag(res.data.tag.name)
+        setFolders(res.data.folders)
+        setTotalPages(res.data.pagy.pages)
+      })
+      .catch((err) => {
+        setErrorMessage(err.message)
+      })
+      .finally(() => {
+        setIsFetching(false)
+      })
+  }
+
+  return {
+    isFetching,
+    errorMessage,
+    fetchTagFolders,
+    tag,
+    folders,
+    totalPages,
+  }
+}

--- a/src/features/folder/hooks/usePostFolder.tsx
+++ b/src/features/folder/hooks/usePostFolder.tsx
@@ -15,6 +15,8 @@ type UsePostFolder = {
 
 type params = {
   name: string
+  color: string
+  tags: string[]
 }
 
 export const usePostFolder = (): UsePostFolder => {

--- a/src/features/folder/hooks/useUpdateFolder.tsx
+++ b/src/features/folder/hooks/useUpdateFolder.tsx
@@ -19,6 +19,7 @@ type params = {
   description?: string
   color?: string
   icon?: string
+  tags?: string[]
 }
 
 export const useUpdateFolder = (): UseUpdateFolder => {
@@ -36,19 +37,19 @@ export const useUpdateFolder = (): UseUpdateFolder => {
 
     await apiClient
       .patch(`/folders/${folderId}`, { folder }, { headers })
-      .then(() => {
+      .then((res) => {
         setAlert({
           isShow: true,
           message: 'フォルダを更新しました',
         })
         setMyFolders((prevMyFolders) => {
           return prevMyFolders.map((prevFolder) =>
-            prevFolder.id.toString() === folderId ? { ...prevFolder, ...folder } : prevFolder,
+            prevFolder.id.toString() === folderId ? { ...prevFolder, ...res.data } : prevFolder,
           )
         })
         setFavoriteFolders((prevFavoriteFolders) => {
           return prevFavoriteFolders.map((prevFolder) =>
-            prevFolder.id.toString() === folderId ? { ...prevFolder, ...folder } : prevFolder,
+            prevFolder.id.toString() === folderId ? { ...prevFolder, ...res.data } : prevFolder,
           )
         })
         navigate(`/folder/${folderId}`)

--- a/src/features/folder/routes/EditFolder.tsx
+++ b/src/features/folder/routes/EditFolder.tsx
@@ -1,17 +1,19 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import DeleteForeverOutlinedIcon from '@mui/icons-material/DeleteForeverOutlined'
-import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
+import FormHelperText from '@mui/material/FormHelperText'
 import IconButton from '@mui/material/IconButton'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { FC, useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
+import { TagsInput } from 'react-tag-input-component'
 import { string, z } from 'zod'
 
+import { Alert } from '@/components/Elements/Alert'
 import { Button } from '@/components/Elements/Button'
 import { InputLabel } from '@/components/Elements/Form/InputLabel'
 import { Link } from '@/components/Elements/Link'
@@ -33,7 +35,10 @@ const schema = z.object({
 type Form = z.infer<typeof schema>
 
 export const EditFolder: FC = () => {
+  const { fetchFolder, folder, isFetching, tags: folderTags } = useFetchFolder()
   const [isOpenConfirmDialog, setIsOpenConfirmDialog] = useState(false)
+  const [tags, setTags] = useState(folderTags)
+  const [validationMessage, setValidationMessage] = useState('')
   const {
     register,
     formState: { errors },
@@ -43,13 +48,19 @@ export const EditFolder: FC = () => {
     resolver: zodResolver(schema),
   })
   const { folderId } = useParams<RouterParams>()
-  const { fetchFolder, folder, isFetching } = useFetchFolder()
   const { updateFolder, errorMessage, isLoading } = useUpdateFolder()
 
   const onSubmit: SubmitHandler<Form> = (data) => {
+    for (let i = 0; i < tags.length; i++) {
+      if (tags[i].length > 20) {
+        setValidationMessage('タグは20文字以下で入力してください')
+        return
+      }
+    }
     const folder = {
       name: data.name,
       description: data.description,
+      tags,
     }
     updateFolder(folder, folderId as string)
   }
@@ -63,9 +74,8 @@ export const EditFolder: FC = () => {
     folder?.description !== undefined && folder?.description !== null
       ? setValue('description', folder.description)
       : setValue('description', '')
+    folderTags !== undefined && setTags(folderTags)
   }, [folder])
-
-  if (isFetching) return <PageLoading />
 
   return (
     <Container maxWidth='md'>
@@ -87,46 +97,56 @@ export const EditFolder: FC = () => {
           sx={{ ml: 'auto' }}
         />
       </Box>
-      {errorMessage !== '' && (
-        <Alert icon={false} severity='error' sx={{ mb: 2 }}>
-          {errorMessage}
-        </Alert>
+      {isFetching ? (
+        <PageLoading />
+      ) : (
+        <>
+          <Alert message={errorMessage} />
+          <Box
+            component='form'
+            noValidate
+            onSubmit={handleSubmit(onSubmit)}
+            sx={{ ...whiteBackgroundProps }}
+          >
+            <InputLabel labelTitle='フォルダ名' inputRequirement='最大 30 文字' isShowChip={true} />
+            <TextField
+              fullWidth
+              size='small'
+              type='text'
+              error={!(errors.name == null)}
+              helperText={errors.name != null ? errors.name.message : ''}
+              sx={{ mb: 4 }}
+              {...register('name')}
+            />
+            <InputLabel labelTitle='説明' isShowChip={true} required={false} />
+            <TextField
+              fullWidth
+              size='small'
+              type='text'
+              error={!(errors.description == null)}
+              helperText={errors.description != null ? errors.description.message : ''}
+              sx={{ mb: 4 }}
+              {...register('description')}
+            />
+            <InputLabel
+              labelTitle='タグ名'
+              inputRequirement='タグ名は20文字までです'
+              required={false}
+              isShowChip={true}
+            />
+            <TagsInput value={tags} onChange={setTags} />
+            <FormHelperText error>{validationMessage}</FormHelperText>
+            <Button
+              isLoading={isLoading}
+              disabled={isLoading}
+              label='保存する'
+              size='large'
+              type='submit'
+              sx={{ mt: 4, mr: 2 }}
+            />
+          </Box>
+        </>
       )}
-      <Box
-        component='form'
-        noValidate
-        onSubmit={handleSubmit(onSubmit)}
-        sx={{ ...whiteBackgroundProps }}
-      >
-        <InputLabel labelTitle='フォルダ名' inputRequirement='最大 30 文字' isShowChip={true} />
-        <TextField
-          fullWidth
-          size='small'
-          type='text'
-          error={!(errors.name == null)}
-          helperText={errors.name != null ? errors.name.message : ''}
-          sx={{ mb: 4 }}
-          {...register('name')}
-        />
-        <InputLabel labelTitle='説明' isShowChip={true} required={false} />
-        <TextField
-          fullWidth
-          size='small'
-          type='text'
-          error={!(errors.description == null)}
-          helperText={errors.description != null ? errors.description.message : ''}
-          sx={{ mb: 4 }}
-          {...register('description')}
-        />
-        <Button
-          isLoading={isLoading}
-          disabled={isLoading}
-          label='保存する'
-          size='large'
-          type='submit'
-          sx={{ mr: 2 }}
-        />
-      </Box>
       <DeleteFolderDialog
         folderId={folderId as string}
         isOpenDialog={isOpenConfirmDialog}

--- a/src/features/folder/routes/FolderDetails.tsx
+++ b/src/features/folder/routes/FolderDetails.tsx
@@ -1,6 +1,7 @@
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined'
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
 import ColorLensRoundedIcon from '@mui/icons-material/ColorLensRounded'
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import IosShareRoundedIcon from '@mui/icons-material/IosShareRounded'
 import ListRoundedIcon from '@mui/icons-material/ListRounded'
@@ -31,6 +32,7 @@ import { sortItems } from '@/components/features/SortSelect/sortItems'
 import { NoContents } from '@/components/Layouts/NoContents'
 import { PageLoading } from '@/components/Layouts/PageLoading'
 import { FavoriteFolderButton } from '@/features/favoriteFolder/components/FavoriteFolderButton'
+import { DeleteFolderDialog } from '@/features/folder/components/Dialog/DeleteFolderDialog'
 import { SetColorAndIconDialog } from '@/features/folder/components/Dialog/SetColorAndIconDialog'
 import { ShareFolderDialog } from '@/features/folder/components/Dialog/ShareFolderDialog'
 import { DynamicIcon } from '@/features/folder/components/DynamicIcon'
@@ -52,6 +54,7 @@ export const FolderDetails: FC = () => {
   const [displayType, setDisplayType] = useState<DisplayType>('list')
   const [isOpenShareFolderDialog, setIsOpenShareFolderDialog] = useState(false)
   const [isOpenSetColorDialog, setIsOpenSetColorDialog] = useState(false)
+  const [isOpenConfirmDialog, setIsOpenConfirmDialog] = useState(false)
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const folderHasLinks = useRecoilValue(folderHasLinksState)
   const isAuthenticated = useRecoilValue(isAuthenticatedState)
@@ -76,15 +79,9 @@ export const FolderDetails: FC = () => {
         setIsOpenShareFolderDialog(true)
         setAnchorEl(null)
       },
-      text: 'フォルダを共有',
+      text: '共有',
       icon: <IosShareRoundedIcon />,
       isShow: true,
-    },
-    {
-      text: 'フォルダを編集',
-      icon: <EditOutlinedIcon />,
-      path: `/folder/${folderId as string}/edit`,
-      isShow: isOwner,
     },
     {
       onClick: () => {
@@ -93,6 +90,21 @@ export const FolderDetails: FC = () => {
       },
       text: '色・アイコンを変更',
       icon: <ColorLensRoundedIcon />,
+      isShow: isOwner,
+    },
+    {
+      text: '編集',
+      icon: <EditOutlinedIcon />,
+      path: `/folder/${folderId as string}/edit`,
+      isShow: isOwner,
+    },
+    {
+      onClick: () => {
+        setIsOpenConfirmDialog(true)
+        setAnchorEl(null)
+      },
+      text: '削除',
+      icon: <DeleteRoundedIcon />,
       isShow: isOwner,
     },
   ]
@@ -165,6 +177,13 @@ export const FolderDetails: FC = () => {
                 setIsOpenDialog={setIsOpenShareFolderDialog}
                 folderName={folder.name}
                 ownerName={folder.user.name}
+              />
+            )}
+            {isOwner && (
+              <DeleteFolderDialog
+                folderId={folderId as string}
+                isOpenDialog={isOpenConfirmDialog}
+                setIsOpenDialog={setIsOpenConfirmDialog}
               />
             )}
           </Box>

--- a/src/features/folder/routes/FolderDetails.tsx
+++ b/src/features/folder/routes/FolderDetails.tsx
@@ -1,10 +1,11 @@
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined'
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
+import ColorLensRoundedIcon from '@mui/icons-material/ColorLensRounded'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
-import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
+import IosShareRoundedIcon from '@mui/icons-material/IosShareRounded'
+import ListRoundedIcon from '@mui/icons-material/ListRounded'
 import StarBorderRoundedIcon from '@mui/icons-material/StarBorderRounded'
 import UpdateIcon from '@mui/icons-material/Update'
-import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
 import Container from '@mui/material/Container'
@@ -16,12 +17,13 @@ import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import Grid from '@mui/material/Unstable_Grid2'
 import { parseISO } from 'date-fns'
-import { useEffect, FC, useState } from 'react'
+import { useEffect, FC, useState, MouseEvent } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
 
-import { Button } from '@/components/Elements/Button'
-import { LinkButton } from '@/components/Elements/Button/LinkButton'
+import { Alert } from '@/components/Elements/Alert'
+import { Menu } from '@/components/Elements/Menu'
+import { MenuItems } from '@/components/Elements/Menu/MenuItems'
 import { DisplayTypeButtonGroup } from '@/components/features/DisplayTypeButtonGroup'
 import { DisplayType } from '@/components/features/DisplayTypeButtonGroup/displayTypeItems'
 import { SortSelect } from '@/components/features/SortSelect'
@@ -32,10 +34,11 @@ import { FavoriteFolderButton } from '@/features/favoriteFolder/components/Favor
 import { SetColorAndIconDialog } from '@/features/folder/components/Dialog/SetColorAndIconDialog'
 import { ShareFolderDialog } from '@/features/folder/components/Dialog/ShareFolderDialog'
 import { DynamicIcon } from '@/features/folder/components/DynamicIcon'
+import { TagList } from '@/features/folder/components/TagList'
 import { useFetchFolder } from '@/features/folder/hooks/useFetchFolder'
 import { LinkCard } from '@/features/link/components/LinkCard'
 import { LinkListItem } from '@/features/link/components/LinkListItem'
-import { Link } from '@/features/link/types/Link'
+import { Link as LinkType } from '@/features/link/types/Link'
 import { NotFound } from '@/features/misc/routes/NotFound'
 import { isAuthenticatedState } from '@/states/AuthAtom'
 import { folderHasLinksState } from '@/states/FolderHasLinksAtom'
@@ -49,6 +52,7 @@ export const FolderDetails: FC = () => {
   const [displayType, setDisplayType] = useState<DisplayType>('list')
   const [isOpenShareFolderDialog, setIsOpenShareFolderDialog] = useState(false)
   const [isOpenSetColorDialog, setIsOpenSetColorDialog] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const folderHasLinks = useRecoilValue(folderHasLinksState)
   const isAuthenticated = useRecoilValue(isAuthenticatedState)
   const { folderId } = useParams<RouterParams>()
@@ -62,6 +66,37 @@ export const FolderDetails: FC = () => {
     setSearchParams({ sort: newSortType })
   }
 
+  const handleOpenMenu = (event: MouseEvent<HTMLElement>): void => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const menuItems: MenuItems = [
+    {
+      onClick: () => {
+        setIsOpenShareFolderDialog(true)
+        setAnchorEl(null)
+      },
+      text: 'フォルダを共有',
+      icon: <IosShareRoundedIcon />,
+      isShow: true,
+    },
+    {
+      text: 'フォルダを編集',
+      icon: <EditOutlinedIcon />,
+      path: `/folder/${folderId as string}/edit`,
+      isShow: isOwner,
+    },
+    {
+      onClick: () => {
+        setIsOpenSetColorDialog(true)
+        setAnchorEl(null)
+      },
+      text: '色・アイコンを変更',
+      icon: <ColorLensRoundedIcon />,
+      isShow: isOwner,
+    },
+  ]
+
   useEffect(() => {
     folderId !== undefined && fetchFolder(folderId, sortType)
   }, [folderId, sortType])
@@ -72,12 +107,8 @@ export const FolderDetails: FC = () => {
 
   return (
     <Container maxWidth='xl'>
-      {errorMessage !== '' && (
-        <Alert icon={false} severity='error' sx={{ mb: 4 }}>
-          {errorMessage}
-        </Alert>
-      )}
-      <Box>
+      <Alert message={errorMessage} />
+      <Box sx={{ mb: 4 }}>
         <Stack direction='row' alignItems='center' justifyContent='space-between' sx={{ mb: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Tooltip
@@ -111,16 +142,32 @@ export const FolderDetails: FC = () => {
               {folder?.name}
             </Typography>
           </Box>
-          {isAuthenticated ? (
-            <FavoriteFolderButton
-              folderId={folderId as string}
-              favoritedData={folder?.folder_favorites}
-            />
-          ) : (
-            <IconButton>
-              <StarBorderRoundedIcon />
+          <Box>
+            {isAuthenticated ? (
+              <>
+                <FavoriteFolderButton
+                  folderId={folderId as string}
+                  favoritedData={folder?.folder_favorites}
+                />
+              </>
+            ) : (
+              <IconButton>
+                <StarBorderRoundedIcon />
+              </IconButton>
+            )}
+            <IconButton onClick={handleOpenMenu}>
+              <ListRoundedIcon />
             </IconButton>
-          )}
+            <Menu anchorEl={anchorEl} setAnchorEl={setAnchorEl} menuItems={menuItems} />
+            {folder?.user !== undefined && (
+              <ShareFolderDialog
+                isOpenDialog={isOpenShareFolderDialog}
+                setIsOpenDialog={setIsOpenShareFolderDialog}
+                folderName={folder.name}
+                ownerName={folder.user.name}
+              />
+            )}
+          </Box>
         </Stack>
         <Grid container spacing={1} sx={{ mb: 1 }}>
           <Grid xs={12} sm='auto'>
@@ -133,8 +180,6 @@ export const FolderDetails: FC = () => {
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
-                color: 'secondary.dark',
-                fontWeight: 'bold',
               }}
             />
           </Grid>
@@ -143,7 +188,7 @@ export const FolderDetails: FC = () => {
               icon={<AccessTimeOutlinedIcon />}
               label={`作成：${diffTime(new Date(), parseISO(folder?.created_at as string))}`}
               variant='outlined'
-              sx={{ border: 'none', color: 'secondary.dark', fontWeight: 'bold' }}
+              sx={{ border: 'none' }}
             />
           </Grid>
           <Grid>
@@ -151,8 +196,11 @@ export const FolderDetails: FC = () => {
               icon={<UpdateIcon />}
               label={`更新：${diffTime(new Date(), parseISO(folder?.updated_at as string))}`}
               variant='outlined'
-              sx={{ border: 'none', color: 'secondary.dark', fontWeight: 'bold' }}
+              sx={{ border: 'none' }}
             />
+          </Grid>
+          <Grid xs={12}>
+            <TagList tags={folder?.tags} />
           </Grid>
         </Grid>
         {folder?.description !== null && (
@@ -160,32 +208,6 @@ export const FolderDetails: FC = () => {
             {folder?.description}
           </Typography>
         )}
-        <Stack direction='row' alignItems='center' spacing={1} sx={{ mt: 2, mb: 3 }}>
-          {folder?.user !== undefined && (
-            <>
-              <Button
-                onClick={() => setIsOpenShareFolderDialog(true)}
-                icon={<ShareOutlinedIcon />}
-                label='共有'
-                variant='outlined'
-              />
-              <ShareFolderDialog
-                isOpenDialog={isOpenShareFolderDialog}
-                setIsOpenDialog={setIsOpenShareFolderDialog}
-                folderName={folder.name}
-                ownerName={folder.user.name}
-              />
-            </>
-          )}
-          {isOwner && (
-            <LinkButton
-              color='secondary'
-              icon={<EditOutlinedIcon />}
-              label='編集'
-              path={`/folder/${folderId as string}/edit`}
-            />
-          )}
-        </Stack>
       </Box>
       {folderHasLinks.length > 0 ? (
         <>
@@ -195,7 +217,7 @@ export const FolderDetails: FC = () => {
           </Stack>
           {displayType === 'list' && (
             <List sx={{ ...whiteBackgroundProps, pl: 1, pr: 0, py: 2 }}>
-              {folderHasLinks?.map((link: Link) => {
+              {folderHasLinks?.map((link: LinkType) => {
                 return (
                   <LinkListItem
                     key={link.id}
@@ -209,7 +231,7 @@ export const FolderDetails: FC = () => {
           )}
           {displayType === 'card' && (
             <Grid container columns={{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }} spacing={3}>
-              {folderHasLinks?.map((link: Link) => {
+              {folderHasLinks?.map((link: LinkType) => {
                 return (
                   <Grid key={link.id} xs={1}>
                     <LinkCard folderId={folderId as string} isOwner={isOwner} link={link} />

--- a/src/features/folder/routes/TagFolders.tsx
+++ b/src/features/folder/routes/TagFolders.tsx
@@ -1,0 +1,83 @@
+import Box from '@mui/material/Box'
+import Container from '@mui/material/Container'
+import { SelectChangeEvent } from '@mui/material/Select'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { FC, useEffect, useState } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
+
+import { Pagination } from '@/components/Elements/Pagination'
+import { DisplayTypeButtonGroup } from '@/components/features/DisplayTypeButtonGroup'
+import { DisplayType } from '@/components/features/DisplayTypeButtonGroup/displayTypeItems'
+import { SortSelect } from '@/components/features/SortSelect'
+import { sortItems } from '@/components/features/SortSelect/sortItems'
+import { NoContents } from '@/components/Layouts/NoContents'
+import { PageLoading } from '@/components/Layouts/PageLoading'
+import { FoldersByCard } from '@/features/folder/components/FoldersByCard'
+import { FoldersByList } from '@/features/folder/components/FoldersByList'
+import { useFetchTagFolders } from '@/features/folder/hooks/useFetchTagFolders'
+import { RouterParams } from '@/types/RouterParams'
+import { SortType } from '@/types/SortType'
+
+export const TagFolders: FC = () => {
+  const [sortType, setSortType] = useState<SortType>('created_asc')
+  const [displayType, setDisplayType] = useState<DisplayType>('list')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { tagId } = useParams<RouterParams>()
+  const noContentsMessage = '作成したフォルダはありません'
+  const { isFetching, errorMessage, fetchTagFolders, tag, folders, totalPages } =
+    useFetchTagFolders()
+
+  const handleChangeSort = (e: SelectChangeEvent): void => {
+    const newSortType = (e.target as HTMLInputElement).value as SortType
+    setSortType(newSortType)
+    setSearchParams({ page: '1', sort: newSortType })
+  }
+
+  useEffect(() => {
+    tagId !== undefined && fetchTagFolders(tagId, searchParams.get('page') as string, sortType)
+  }, [tagId, searchParams, sortType])
+
+  return (
+    <Container maxWidth='md'>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant='h1'>タグ「{tag}」のフォルダ</Typography>
+        {folders !== undefined && folders.length > 0 && (
+          <Stack direction='row' justifyContent='flex-end' alignItems='center' sx={{ mt: 3 }}>
+            <SortSelect sort={sortType} selectItems={sortItems} handleChange={handleChangeSort} />
+            <DisplayTypeButtonGroup displayType={displayType} setDisplayType={setDisplayType} />
+          </Stack>
+        )}
+      </Box>
+      {isFetching ? (
+        <PageLoading />
+      ) : folders !== undefined && folders.length > 0 ? (
+        <>
+          {displayType === 'list' && (
+            <FoldersByList
+              errorMessage={errorMessage}
+              folders={folders}
+              isLoading={isFetching}
+              noContentsMessage={noContentsMessage}
+            />
+          )}
+          {displayType === 'card' && (
+            <FoldersByCard
+              errorMessage={errorMessage}
+              folders={folders}
+              isLoading={isFetching}
+              noContentsMessage={noContentsMessage}
+            />
+          )}
+          <Pagination
+            currentPage={parseInt(searchParams.get('page') as string)}
+            totalPages={totalPages}
+            sortType={sortType}
+          />
+        </>
+      ) : (
+        <NoContents message='該当タグのフォルダは存在しません' />
+      )}
+    </Container>
+  )
+}

--- a/src/features/folder/types/Folder.ts
+++ b/src/features/folder/types/Folder.ts
@@ -1,4 +1,5 @@
 import { FolderFavorites } from '@/features/favoriteFolder/types'
+import { Tag } from '@/features/folder/types/Tag'
 import { Link } from '@/features/link/types/Link'
 import { User } from '@/features/user/types/User'
 
@@ -14,4 +15,5 @@ export type Folder = {
   links?: Link[]
   user?: User
   folder_favorites?: FolderFavorites[]
+  tags?: Tag[]
 }

--- a/src/features/folder/types/Tag.ts
+++ b/src/features/folder/types/Tag.ts
@@ -1,0 +1,6 @@
+export type Tag = {
+  id: number
+  name: string
+  updated_at: string
+  created_at: string
+}

--- a/src/features/link/components/LinkCard.tsx
+++ b/src/features/link/components/LinkCard.tsx
@@ -1,3 +1,6 @@
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded'
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded'
+import EditRoundedIcon from '@mui/icons-material/EditRounded'
 import ImageNotSupportedTwoToneIcon from '@mui/icons-material/ImageNotSupportedTwoTone'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import Box from '@mui/material/Box'
@@ -12,11 +15,9 @@ import Typography from '@mui/material/Typography'
 import { parseISO } from 'date-fns'
 import { Image } from 'mui-image'
 import { FC, MouseEvent, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useSetRecoilState } from 'recoil'
 
 import { Menu } from '@/components/Elements/Menu'
-import { MenuItems } from '@/components/Elements/Menu/MenuItems'
 import { DeleteLinkDialog } from '@/features/link/components/DeleteLinkDialog'
 import { Link as LinkType } from '@/features/link/types/Link'
 import { alertState } from '@/states/AlertAtom'
@@ -33,28 +34,28 @@ export const LinkCard: FC<LinkCardProps> = ({ link, folderId, isOwner = false })
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [isOpenDialog, setIsOpenDialog] = useState<boolean>(false)
   const setAlert = useSetRecoilState(alertState)
-  const navigate = useNavigate()
   const IMAGE_HEIGHT = 130
 
   const handleOpenMenu = (event: MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget)
   }
 
-  const ownerMenuItems: MenuItems = [
+  const menuItems = [
     {
       onClick: () => {
         navigator.clipboard.writeText(link.url)
-        setAlert({ isShow: true, message: 'クリップボードにリンクをコピーしました' })
+        setAlert({ isShow: true, message: 'クリップボードにURLをコピーしました' })
         setAnchorEl(null)
       },
-      text: 'クリップボードにリンクをコピー',
+      text: 'クリップボードにURLをコピー',
+      icon: <ContentCopyRoundedIcon />,
+      isShow: true,
     },
     {
-      onClick: () => {
-        navigate(`/folder/${folderId}/link/${link.id}`)
-        setAnchorEl(null)
-      },
       text: '編集',
+      icon: <EditRoundedIcon />,
+      path: `/folder/${folderId}/link/${link.id}`,
+      isShow: isOwner,
     },
     {
       onClick: () => {
@@ -62,17 +63,8 @@ export const LinkCard: FC<LinkCardProps> = ({ link, folderId, isOwner = false })
         setAnchorEl(null)
       },
       text: '削除',
-    },
-  ]
-
-  const notOwnerMenuItems: MenuItems = [
-    {
-      onClick: () => {
-        navigator.clipboard.writeText(link.url)
-        setAlert({ isShow: true, message: 'クリップボードにリンクをコピーしました' })
-        setAnchorEl(null)
-      },
-      text: 'クリップボードにリンクをコピー',
+      icon: <DeleteRoundedIcon />,
+      isShow: isOwner,
     },
   ]
 
@@ -145,11 +137,7 @@ export const LinkCard: FC<LinkCardProps> = ({ link, folderId, isOwner = false })
         <IconButton onClick={handleOpenMenu} edge='end' size='small' sx={{ ml: 'auto' }}>
           <MoreVertIcon />
         </IconButton>
-        <Menu
-          anchorEl={anchorEl}
-          handleCloseMenu={() => setAnchorEl(null)}
-          menuItems={isOwner ? ownerMenuItems : notOwnerMenuItems}
-        />
+        <Menu anchorEl={anchorEl} setAnchorEl={setAnchorEl} menuItems={menuItems} />
         {isOwner && folderId !== undefined && link.id !== undefined && (
           <DeleteLinkDialog
             folderId={folderId}

--- a/src/features/link/components/LinkListItem.tsx
+++ b/src/features/link/components/LinkListItem.tsx
@@ -1,3 +1,6 @@
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded'
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded'
+import EditRoundedIcon from '@mui/icons-material/EditRounded'
 import ImageNotSupportedTwoToneIcon from '@mui/icons-material/ImageNotSupportedTwoTone'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import IconButton from '@mui/material/IconButton'
@@ -10,11 +13,9 @@ import Typography from '@mui/material/Typography'
 import { parseISO } from 'date-fns'
 import { Image } from 'mui-image'
 import { FC, MouseEvent, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useSetRecoilState } from 'recoil'
 
 import { Menu } from '@/components/Elements/Menu'
-import { MenuItems } from '@/components/Elements/Menu/MenuItems'
 import { DeleteLinkDialog } from '@/features/link/components/DeleteLinkDialog'
 import { Link as LinkType } from '@/features/link/types/Link'
 import { useMedia } from '@/hooks/useMedia'
@@ -34,27 +35,26 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner = false,
   const setAlert = useSetRecoilState(alertState)
   const { isDesktopScreen } = useMedia()
 
-  const navigate = useNavigate()
-
   const handleOpenMenu = (event: MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget)
   }
 
-  const ownerMenuItems: MenuItems = [
+  const menuItems = [
     {
       onClick: () => {
         navigator.clipboard.writeText(link.url)
-        setAlert({ isShow: true, message: 'クリップボードにリンクをコピーしました' })
+        setAlert({ isShow: true, message: 'クリップボードにURLをコピーしました' })
         setAnchorEl(null)
       },
-      text: 'クリップボードにリンクをコピー',
+      text: 'クリップボードにURLをコピー',
+      icon: <ContentCopyRoundedIcon />,
+      isShow: true,
     },
     {
-      onClick: () => {
-        navigate(`/folder/${folderId}/link/${link.id}`)
-        setAnchorEl(null)
-      },
       text: '編集',
+      icon: <EditRoundedIcon />,
+      path: `/folder/${folderId}/link/${link.id}`,
+      isShow: isOwner,
     },
     {
       onClick: () => {
@@ -62,17 +62,8 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner = false,
         setAnchorEl(null)
       },
       text: '削除',
-    },
-  ]
-
-  const notOwnerMenuItems: MenuItems = [
-    {
-      onClick: () => {
-        navigator.clipboard.writeText(link.url)
-        setAlert({ isShow: true, message: 'クリップボードにリンクをコピーしました' })
-        setAnchorEl(null)
-      },
-      text: 'クリップボードにリンクをコピー',
+      icon: <DeleteRoundedIcon />,
+      isShow: isOwner,
     },
   ]
 
@@ -130,11 +121,7 @@ export const LinkListItem: FC<LinkListItemProps> = ({ folderId, isOwner = false,
       <IconButton onClick={handleOpenMenu} edge='end' size='small' sx={{ mr: 0.5 }}>
         <MoreVertIcon />
       </IconButton>
-      <Menu
-        anchorEl={anchorEl}
-        handleCloseMenu={() => setAnchorEl(null)}
-        menuItems={isOwner ? ownerMenuItems : notOwnerMenuItems}
-      />
+      <Menu anchorEl={anchorEl} setAnchorEl={setAnchorEl} menuItems={menuItems} />
       {isOwner && folderId !== undefined && link.id !== undefined && (
         <DeleteLinkDialog
           folderId={folderId}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { parseCookies } from 'nookies'
 import { FC, useEffect } from 'react'
-import { Navigate, Outlet, Route, Routes } from 'react-router-dom'
+import { Outlet, Route, Routes } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
 
 import { MainLayout } from '@/components/Layouts/MainLayout'
@@ -13,6 +13,7 @@ import { FavoriteFolders } from '@/features/favoriteFolder/routes/FavoriteFolder
 import { EditFolder } from '@/features/folder/routes/EditFolder'
 import { FolderDetails } from '@/features/folder/routes/FolderDetails'
 import { MyFolders } from '@/features/folder/routes/MyFolders'
+import { TagFolders } from '@/features/folder/routes/TagFolders'
 import { EditLink } from '@/features/link/routes/EditLink'
 import { MyLinks } from '@/features/link/routes/MyLinks'
 import { NewLink } from '@/features/link/routes/NewLink'
@@ -48,8 +49,6 @@ export const AppRoutes: FC = () => {
   )
 
   const AuthPage: FC = () => {
-    if (authenticated) return <Navigate to='/myfolders' replace={false} />
-
     return (
       <>
         <AuthHeader />
@@ -72,6 +71,7 @@ export const AppRoutes: FC = () => {
         <Route path='/myfolders' element={<AuthGuard component={<MyFolders />} />} />
         <Route path='/mylinks' element={<AuthGuard component={<MyLinks />} />} />
         <Route path='/favorite' element={<AuthGuard component={<FavoriteFolders />} />} />
+        <Route path='/tag/:tagId' element={<AuthGuard component={<TagFolders />} />} />
         <Route path='/folder/:folderId' element={<FolderDetails />} />
         <Route path='/folder/:folderId/edit' element={<AuthGuard component={<EditFolder />} />} />
         <Route path='/new/link' element={<AuthGuard component={<NewLink />} />} />

--- a/src/states/FavoriteFolders.ts
+++ b/src/states/FavoriteFolders.ts
@@ -14,6 +14,7 @@ export const favoriteFoldersState = atom<FavoriteFolders>({
       updated_at: '',
       links: undefined,
       user: undefined,
+      tags: undefined
     },
   ],
 })

--- a/src/states/MyFoldersAtom.ts
+++ b/src/states/MyFoldersAtom.ts
@@ -14,6 +14,7 @@ export const myFoldersState = atom<myFolders>({
       updated_at: '',
       links: undefined,
       user: undefined,
+      tags: undefined
     },
   ],
 })

--- a/src/types/RouterParams.ts
+++ b/src/types/RouterParams.ts
@@ -1,4 +1,5 @@
 export type RouterParams = {
   readonly folderId?: string
   readonly linkId?: string
+  readonly tagId?: string
 }


### PR DESCRIPTION
Closes #41 

## タグ付け機能を実装
- 以下 component にタグ付け用の textfield を追加
  - フォルダ作成ダイアログ
  - フォルダ編集フォーム
- フォルダ詳細ページにタグを表示
- タグごとのフォルダ一覧表示ページを追加
  - ページネーションにて実装
- フォルダ詳細ページに以下を内包するメニューボタンを追加
  - フォルダ編集へのリンク
  - フォルダ削除
  - 色・アイコンの変更
  - フォルダの共有

## 対応する API 側 issue
https://github.com/FutaMiyazaki/gathelink-api/issues/34